### PR TITLE
fix autocmd bug

### DIFF
--- a/plugin/cppSyntaxCheck.vim
+++ b/plugin/cppSyntaxCheck.vim
@@ -194,8 +194,12 @@ function! CPPShowCompMsg()
     endif
 endfunction
 
-autocmd BufWritePost *.cpp,*.c,*.h,*.hpp,*.cc call s:CheckError()
-autocmd CursorHold *.cpp,*.h,*.c,*.hpp,*.cc call s:ShowErrMsg()
-autocmd CursorMoved *.cpp,*.h,*.c,*.hpp,*.cc call s:ShowErrMsg()
+augroup cppsyntax
+	autocmd!
+	autocmd BufWritePost *.cpp,*.c,*.h,*.hpp,*.cc call s:CheckError()
+	autocmd CursorHold *.cpp,*.h,*.c,*.hpp,*.cc call s:ShowErrMsg()
+	autocmd CursorMoved *.cpp,*.h,*.c,*.hpp,*.cc call s:ShowErrMsg()
+augroup END
+
 map <Leader>s :cn<cr>
 map <Leader>p :call CPPShowCompMsg()<cr>


### PR DESCRIPTION
Hello there, love the plugin. It seems though every time a new file is opened in vim, more autocmd's for your functions are created (causing a file to be compiled multiple times). This is because the plugin is being sourced each time and your `autocmd`'s are not protected with a `augroup`. I did the fix for ya (((: Fantastic work by the way, I love how portable and easy to use it is.